### PR TITLE
Feat: Added inputs variables dereferencing support [CFG-1501]

### DIFF
--- a/terraform/constants.go
+++ b/terraform/constants.go
@@ -1,0 +1,5 @@
+package terraform
+
+const (
+	TF = ".tf"
+)

--- a/terraform/hcl2json.go
+++ b/terraform/hcl2json.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"encoding/json"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -1,0 +1,16 @@
+package terraform
+
+import "github.com/hashicorp/hcl/v2"
+
+//Taken from https://github.com/hashicorp/terraform/blob/f266d1ee82d1fa4d882c146cc131fec4bef753cf/internal/configs/parser_config.go#L214
+// tfFileSchema is the schema for the top-level of a config file. We use
+// the low-level HCL API for this level so we can easily deal with each
+// block type separately with its own decoding logic.
+var tfFileVariableSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type:       "variable",
+			LabelNames: []string{"name"},
+		},
+	},
+}


### PR DESCRIPTION
### What this does

#### Adds supporting reading variable values in Terraform (.tf) files.

This is done to help on our vision to create better TF support for our product and find more issues that might have been ignored so far because they would be coming from variable values.
This PR is to support input variables, with or without default values. 

### Background context

In the [Decision Document](https://www.notion.so/snyk/Terraform-Variable-Dereferencing-in-the-Snyk-CLI-24c2c15f5a0942429b7454b0796a4298), we decided to create a new library in Go where the implementation for this would live.

We already have played [a spike](https://www.notion.so/snyk/POC-Golang-based-Terraform-var-dereferencing-and-Terraform-to-JSON-conversion-with-merging-all-cont-cc931b9f965347ab826f0b7076b676cf#9e93f530bb1f4d74bd85055a706b948e) on how this could look like.

We plan to build a parser that can deal with (end goal):
- Variable blocks inside HCL (.tf) files
- Local blocks inside HCL (.tf) files
- Variables with default values
- Variables in the terraform.tfvars default file
- A definition of input variables can be found [here](https://www.terraform.io/language/values/variables).

**As part of this ticket**, we will only be adding support for input variables (and defaults).


### Additional information

- [Jira Issue CFG-1501](https://www.terraform.io/language/values/variables)
-  [Slack thread](https://snyk.slack.com/archives/C030WL9BLSW/p1644402193378949)