### PR TITLE
feat: add debugging logs [CFG-1582]

### DIFF
--- a/terraform/errors.go
+++ b/terraform/errors.go
@@ -1,5 +1,7 @@
 package terraform
 
+import "fmt"
+
 type CustomError struct {
 	message   string
 	errors    []error
@@ -7,8 +9,19 @@ type CustomError struct {
 }
 
 func (err *CustomError) Error() string {
-	// TODO: include more details here with user information
 	return err.message
+}
+
+func GenerateDebugLogs(err error) string {
+	customError, ok := err.(*CustomError)
+
+	debugging := ""
+	if ok {
+		for _, e := range customError.errors {
+			debugging = fmt.Sprintf("%s\n%s", debugging, e.Error())
+		}
+	}
+	return debugging
 }
 
 func isUserError(err error) bool {

--- a/terraform/errors_test.go
+++ b/terraform/errors_test.go
@@ -1,0 +1,40 @@
+package terraform
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateDebugLogsNotCustomError(t *testing.T) {
+	actual := GenerateDebugLogs(errors.New("Test"))
+	assert.Equal(t, "", actual)
+}
+
+func TestGenerateDebugLogsCustomErrorWithNoErrors(t *testing.T) {
+	actual := GenerateDebugLogs(&CustomError{
+		message: "Test",
+		errors:  []error{},
+	})
+	assert.Equal(t, "", actual)
+}
+
+func TestGenerateDebugLogsCustomErrorWithErrors(t *testing.T) {
+	actual := GenerateDebugLogs(&CustomError{
+		message: "Test",
+		errors: []error{
+			errors.New("Error1"),
+			errors.New("Error2"),
+		},
+	})
+	assert.Equal(t, "\nError1\nError2", actual)
+}
+
+func TestIsUserError(t *testing.T) {
+	assert.False(t, isUserError(errors.New("Test")))
+	assert.False(t, isUserError(&CustomError{
+		message: "Test",
+		errors:  []error{},
+	}))
+}

--- a/terraform/hcl2json.go
+++ b/terraform/hcl2json.go
@@ -11,6 +11,7 @@ import (
 func ParseModule(files map[string]interface{}) map[string]interface{} {
 	failedFiles := make(map[string]interface{}) // will contain files alongside user errors
 	parsedFiles := make(map[string]interface{})
+	debugLogs := make(map[string]interface{})
 
 	variablesMaps := map[string]VariableMap{}
 	for fileName, fileContentInterface := range files {
@@ -24,6 +25,7 @@ func ParseModule(files map[string]interface{}) map[string]interface{} {
 			if err != nil {
 				// skip non-user errors
 				if isUserError(err) {
+					debugLogs[fileName] = GenerateDebugLogs(err)
 					failedFiles[fileName] = err.Error()
 				}
 				continue
@@ -42,6 +44,7 @@ func ParseModule(files map[string]interface{}) map[string]interface{} {
 			if err != nil {
 				// skip non-user errors
 				if isUserError(err) {
+					debugLogs[fileName] = GenerateDebugLogs(err)
 					failedFiles[fileName] = err.Error()
 				}
 				continue
@@ -53,6 +56,7 @@ func ParseModule(files map[string]interface{}) map[string]interface{} {
 	return map[string]interface{}{
 		"parsedFiles": parsedFiles,
 		"failedFiles": failedFiles,
+		"debugLogs":   debugLogs,
 	}
 }
 

--- a/terraform/hcl2json_test.go
+++ b/terraform/hcl2json_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -696,6 +697,7 @@ variable "dummy" {
 					"test1.tf": jsonOutput,
 					"test2.tf": jsonOutput,
 				},
+				"debugLogs": map[string]interface{}{},
 			},
 		}, {
 			name: "A valid .tf and terraform.tfvars file with no overlapping variables and no error",
@@ -709,6 +711,7 @@ resource "aws_security_group" "allow_ssh" {
 				"terraform.tfvars": `dummy = "dummy"`,
 			},
 			expected: map[string]interface{}{
+				"debugLogs":   map[string]interface{}{},
 				"failedFiles": map[string]interface{}{},
 				"parsedFiles": map[string]interface{}{
 					"test.tf": `{
@@ -741,6 +744,7 @@ variable "dummy" {
 				"test_terraform.tfvars": `dummy = "dummy_override"`,
 			},
 			expected: map[string]interface{}{
+				"debugLogs":   map[string]interface{}{},
 				"failedFiles": map[string]interface{}{},
 				"parsedFiles": map[string]interface{}{
 					"test.tf": `{
@@ -779,6 +783,7 @@ variable "dummy" {
 				"terraform.tfvars": `dummy = "dummy_override"`,
 			},
 			expected: map[string]interface{}{
+				"debugLogs":   map[string]interface{}{},
 				"failedFiles": map[string]interface{}{},
 				"parsedFiles": map[string]interface{}{
 					"test.tf": `{
@@ -819,6 +824,7 @@ variable "dummy" {
 				"a_test.auto.tfvars": `dummy = "a_dummy_override"`,
 			},
 			expected: map[string]interface{}{
+				"debugLogs":   map[string]interface{}{},
 				"failedFiles": map[string]interface{}{},
 				"parsedFiles": map[string]interface{}{
 					"test.tf": `{
@@ -928,6 +934,7 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 `,
 			},
 			expected: map[string]interface{}{
+				"debugLogs":   map[string]interface{}{},
 				"failedFiles": map[string]interface{}{},
 				"parsedFiles": map[string]interface{}{
 					"variables.tf": `{
@@ -1024,8 +1031,10 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 				"test2.tf": fileContent,
 			},
 			extractErr: &CustomError{
-				message:   "User error",
-				errors:    []error{},
+				message: "User error",
+				errors: []error{
+					errors.New("Test"),
+				},
 				userError: true,
 			},
 			expected: map[string]interface{}{
@@ -1034,6 +1043,9 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 				},
 				"parsedFiles": map[string]interface{}{
 					"test2.tf": jsonOutput,
+				},
+				"debugLogs": map[string]interface{}{
+					"fail.tf": "\nTest",
 				},
 			},
 		},
@@ -1044,8 +1056,10 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 				"test2.tf": fileContent,
 			},
 			extractErr: &CustomError{
-				message:   "Internal error",
-				errors:    []error{},
+				message: "Internal error",
+				errors: []error{
+					errors.New("Test"),
+				},
 				userError: false,
 			},
 			expected: map[string]interface{}{
@@ -1054,6 +1068,7 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 					"fail.tf":  jsonOutput, // it's intentional for files that fail with internal errors at extraction time to still try to parse as the internal error can be a flake
 					"test2.tf": jsonOutput,
 				},
+				"debugLogs": map[string]interface{}{},
 			},
 		},
 		{
@@ -1063,8 +1078,10 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 				"test2.tf": fileContent,
 			},
 			parseErr: &CustomError{
-				message:   "User error",
-				errors:    []error{},
+				message: "User error",
+				errors: []error{
+					errors.New("Test"),
+				},
 				userError: true,
 			},
 			expected: map[string]interface{}{
@@ -1073,6 +1090,9 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 				},
 				"parsedFiles": map[string]interface{}{
 					"test2.tf": jsonOutput,
+				},
+				"debugLogs": map[string]interface{}{
+					"fail.tf": "\nTest",
 				},
 			},
 		},
@@ -1083,8 +1103,10 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 				"test2.tf": fileContent,
 			},
 			parseErr: &CustomError{
-				message:   "Internal error",
-				errors:    []error{},
+				message: "Internal error",
+				errors: []error{
+					errors.New("Test"),
+				},
 				userError: false,
 			},
 			expected: map[string]interface{}{
@@ -1092,6 +1114,7 @@ remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
 				"parsedFiles": map[string]interface{}{
 					"test2.tf": jsonOutput,
 				},
+				"debugLogs": map[string]interface{}{},
 			},
 		},
 	}


### PR DESCRIPTION
This PR exposes a new return value from the `ParseModule` function, namely `debugLogs`. This contains extra debugging logs from the parsing, split by file name. The logs can be used in the `snyk` CLI to provide more context to the user about the error.

The debug logs are only populated for user errors, which we consider actionable.

[CFG-1582](https://snyksec.atlassian.net/browse/CFG-1582)