### PR TITLE
feat: dereference variables from terraform.tfvars and *.auto.tfvars [CFG-1502]

### DIFF
--- a/terraform/constants.go
+++ b/terraform/constants.go
@@ -1,5 +1,12 @@
 package terraform
 
 const (
-	TF = ".tf"
+	TF          = ".tf"
+	TFVARS      = ".tfvars"
+	AUTO_TFVARS = ".auto.tfvars"
+
+	DEFAULT_TFVARS = "terraform.tfvars"
 )
+
+var VALID_VARIABLE_FILES = [...]string{TF, AUTO_TFVARS}
+var VALID_TERRAFORM_FILES = [...]string{TF}

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -1,0 +1,104 @@
+package terraform
+
+import (
+	"sort"
+	"strings"
+)
+
+func isTerraformTfvarsFile(fileName string) bool {
+	// the terraform.tfvars file is a strict file name so make sure the file isn't called something like *terraform.tfvars
+	return fileName == DEFAULT_TFVARS || strings.HasSuffix(fileName, "/"+DEFAULT_TFVARS)
+}
+
+func isValidVariableFile(fileName string) bool {
+	if isTerraformTfvarsFile(fileName) {
+		return true
+	}
+	for _, fileExt := range VALID_VARIABLE_FILES {
+		if strings.HasSuffix(fileName, fileExt) {
+			return true
+		}
+	}
+	return false
+}
+
+func isValidTerraformFile(fileName string) bool {
+	for _, fileExt := range VALID_TERRAFORM_FILES {
+		if strings.HasSuffix(fileName, fileExt) {
+			return true
+		}
+	}
+	return false
+}
+
+type PrioritisableFile struct {
+	fileName string
+	priority int
+}
+
+func createPrioritisableFile(fileName string) PrioritisableFile {
+	// TODO: Variables in terraform.tfvars.json files come after terraform.tfvars and before .auto.tfvars (not supported)
+	// TODO: Variables in -var and -var-file options come after .auto.tfvars and .auto.tfvars.json files, in the order they are provided (not supported)
+
+	// The file with the biggest value has the highest priority
+	if strings.HasSuffix(fileName, TF) {
+		// Default values have lowest priority (in .tf files)
+		return PrioritisableFile{
+			fileName: fileName,
+			priority: 1,
+		}
+	} else if isTerraformTfvarsFile(fileName) {
+		// Then variables in the terraform.tfvars file if it exists
+		return PrioritisableFile{
+			fileName: fileName,
+			priority: 2,
+		}
+	} else if strings.HasSuffix(fileName, AUTO_TFVARS) {
+		// Then variables in .auto.tfvars, in lexical order
+		// TODO: or.auto.tfvars.json (not supported)
+		return PrioritisableFile{
+			fileName: fileName,
+			priority: 3,
+		}
+	} else {
+		// Won't happen
+		return PrioritisableFile{
+			fileName: fileName,
+			priority: 0,
+		}
+	}
+}
+
+func orderFilesByPriority(fileNames []string) []string {
+	prioritisableFiles := make([]PrioritisableFile, 0, len(fileNames))
+
+	for _, fileName := range fileNames {
+		prioritisableFiles = append(prioritisableFiles, createPrioritisableFile(fileName))
+	}
+
+	sort.Slice(prioritisableFiles, func(i, j int) bool {
+		// sort random files as the lowest priority
+		if prioritisableFiles[i].priority == 0 || prioritisableFiles[j].priority == 0 {
+			return i >= j
+		}
+
+		if prioritisableFiles[i].priority == prioritisableFiles[j].priority {
+			// sort files with the same priority and .auto.tfvars lexically
+			if strings.HasSuffix(prioritisableFiles[i].fileName, AUTO_TFVARS) {
+				x := strings.Compare(prioritisableFiles[i].fileName, prioritisableFiles[j].fileName)
+				return x <= 0
+			}
+			// do not sort files with the same priority and non .auto.tfvars
+			return i <= j
+		}
+
+		return prioritisableFiles[i].priority < prioritisableFiles[j].priority
+	})
+
+	prioritisedFileNames := make([]string, 0, len(fileNames))
+	for _, prioritisableFile := range prioritisableFiles {
+		prioritisedFileNames = append(prioritisedFileNames, prioritisableFile.fileName)
+	}
+
+	return prioritisedFileNames
+}

--- a/terraform/utils_test.go
+++ b/terraform/utils_test.go
@@ -1,0 +1,55 @@
+package terraform
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsTerraformTfvarsFile(t *testing.T) {
+	assert.True(t, isTerraformTfvarsFile("terraform.tfvars"))
+	assert.True(t, isTerraformTfvarsFile("path/to/terraform.tfvars"))
+	assert.False(t, isTerraformTfvarsFile("test_terraform.tfvars"))
+}
+
+func TestIsValidVariableFile(t *testing.T) {
+	assert.True(t, isValidVariableFile("path/to/terraform.tfvars"))
+	assert.False(t, isValidVariableFile("path/to/terraform.tfvars.json"))
+	assert.True(t, isValidVariableFile("path/to/test.tf"))
+	assert.True(t, isValidVariableFile("path/to/test.auto.tfvars"))
+	assert.False(t, isValidVariableFile("path/to/test.auto.tfvars.json"))
+}
+
+func TestIsValidTerraformFile(t *testing.T) {
+	assert.False(t, isValidTerraformFile("path/to/terraform.tfvars"))
+	assert.False(t, isValidTerraformFile("path/to/terraform.tfvars.json"))
+	assert.True(t, isValidTerraformFile("path/to/test.tf"))
+	assert.False(t, isValidTerraformFile("path/to/test.auto.tfvars"))
+	assert.False(t, isValidTerraformFile("path/to/test.auto.tfvars.json"))
+}
+
+func TestOrderFilesByPriority(t *testing.T) {
+	input := []string{
+		"c.auto.tfvars",
+		"b.tf",
+		"a.tf",
+		"terraform.tfvars",
+		"d.tf",
+		"random",
+		"b.auto.tfvars",
+		"c.tf",
+		"a.auto.tfvars",
+	}
+	expected := []string{
+		"random",
+		"b.tf",
+		"a.tf",
+		"d.tf",
+		"c.tf",
+		"terraform.tfvars",
+		"a.auto.tfvars",
+		"b.auto.tfvars",
+		"c.auto.tfvars",
+	}
+	actual := orderFilesByPriority(input)
+	assert.Equal(t, expected, actual)
+}

--- a/terraform/variables.go
+++ b/terraform/variables.go
@@ -3,41 +3,48 @@ package terraform
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
+	"strings"
 )
 
 type VariableMap map[string]cty.Value
 
-func extractFromFile(file *hcl.File) (VariableMap, hcl.Diagnostics) {
-	// TODO: remove temporary dummy locals
-	// implement "local" when we do local values
+func extractFromFile(fileName string, file *hcl.File) (VariableMap, hcl.Diagnostics) {
+	varMap := VariableMap{}
 
-	varMap, hclDiags := extractFromTfFile(file)
-	if hclDiags.HasErrors() {
-		return VariableMap{}, hclDiags
+	var variables VariableMap
+	var hclDiags hcl.Diagnostics
+	if strings.HasSuffix(fileName, TF) {
+		variables, hclDiags = extractFromTfFile(file)
+		if hclDiags.HasErrors() {
+			return varMap, hclDiags
+		}
+	} else if strings.HasSuffix(fileName, TFVARS) {
+		variables, hclDiags = extractFromTfvarsFile(file)
 	}
 
-	return VariableMap{
-		"var": cty.ObjectVal(varMap),
-		"local": cty.ObjectVal(VariableMap{
-			"dummy": cty.StringVal("dummy"),
-		}),
-	}, hclDiags
+	varMap["var"] = cty.ObjectVal(variables)
+
+	// TODO: remove temporary dummy locals and implement local values
+	varMap["local"] = cty.ObjectVal(VariableMap{
+		"dummy": cty.StringVal("dummy"),
+	})
+
+	return varMap, hclDiags
 }
 
 // Logic inspired from https://github.com/hashicorp/terraform/blob/f266d1ee82d1fa4d882c146cc131fec4bef753cf/internal/configs/named_values.go#L113
 func extractFromTfFile(file *hcl.File) (VariableMap, hcl.Diagnostics) {
 	varMap := VariableMap{}
-	bodyContent, _, hclDiags := file.Body.PartialContent(tfFileVariableSchema)
 
+	bodyContent, _, hclDiags := file.Body.PartialContent(tfFileVariableSchema)
 	if hclDiags.HasErrors() {
-		return VariableMap{}, hclDiags
+		return varMap, hclDiags
 	}
 
 	for _, block := range bodyContent.Blocks {
 		name := block.Labels[0]
 
 		attrs, _ := block.Body.JustAttributes()
-
 		defaultValue := attrs["default"]
 		if defaultValue != nil {
 			value, diags := defaultValue.Expr.Value(&hcl.EvalContext{Functions: terraformFunctions})
@@ -52,13 +59,36 @@ func extractFromTfFile(file *hcl.File) (VariableMap, hcl.Diagnostics) {
 	return varMap, hclDiags
 }
 
-func mergeVariables(variableMaps []VariableMap) VariableMap {
+func extractFromTfvarsFile(file *hcl.File) (VariableMap, hcl.Diagnostics) {
+	varMap := VariableMap{}
+
+	attrs, hclDiags := file.Body.JustAttributes()
+
+	for name, attr := range attrs {
+		value, diags := attr.Expr.Value(&hcl.EvalContext{Functions: terraformFunctions})
+		if diags.HasErrors() {
+			continue
+		}
+		varMap[name] = value
+	}
+	return varMap, hclDiags
+}
+
+func mergeVariables(variableMaps map[string]VariableMap) VariableMap {
 	combinedVariableMaps := make(VariableMap)
 
-	combinedVars := make(VariableMap)
-	for _, variableMap := range variableMaps {
-		vars := variableMap["var"].AsValueMap()
-		for variable, value := range vars {
+	combinedVars := make(map[string]cty.Value)
+
+	fileNames := make([]string, 0, len(variableMaps))
+	for fileName := range variableMaps {
+		fileNames = append(fileNames, fileName)
+	}
+
+	prioritisedFileNames := orderFilesByPriority(fileNames)
+
+	for _, fileName := range prioritisedFileNames {
+		variableMap := variableMaps[fileName]["var"].AsValueMap()
+		for variable, value := range variableMap {
 			combinedVars[variable] = value
 		}
 	}


### PR DESCRIPTION
This PR enables support for dereferencing variables defined in`terraform.tfvars` and `*.auto.tfvars` . It does not aim to support `terraform.tfvars.json` and `*.auto.tfvars.json` files, or files provided via the `-var` and `-var-file`flags. Tfvars files are explained [here](https://www.terraform.io/language/values/variables#variable-definitions-tfvars-files)

It keeps in mind variable definition precedences, as per [this](https://www.terraform.io/language/values/variables#variable-definition-precedence) doc. So default variables can be overridden by `terraform.tfvars` variables, then by `*.auto.tfvars` variables with the last file in alphabetical order overriding everything (if already defined).

The `ParseModule` was modified so that files ending in `.tf` and `.tfvars` have variables extracted from them, then the precedence is dealt with when merging variables in `mergeVariables` by ordering the file names based on priority. Then, we only parse `.tf` files.

Jira ticket: https://snyksec.atlassian.net/browse/CFG-1502