### PR TITLE
test: remove redundant test

### DIFF
--- a/terraform/variables_test.go
+++ b/terraform/variables_test.go
@@ -60,27 +60,6 @@ func TestMergeVariablesOverridesWithTerraformTfvars(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestMergeVariablesDoesNotOverrideWithRandomTfvars(t *testing.T) {
-	input := map[string]VariableMap{
-		"test1.tf": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val1"),
-			}),
-		},
-		"test.tfvars": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val2")}),
-		},
-	}
-	expected := VariableMap{
-		"var": cty.ObjectVal(VariableMap{
-			"var": cty.StringVal("val1"),
-		}),
-	}
-	actual := mergeVariables(input)
-	assert.Equal(t, expected, actual)
-}
-
 func TestMergeVariablesOverridesWithAnyAutoTfvars(t *testing.T) {
 	input := map[string]VariableMap{
 		"test1.tf": VariableMap{


### PR DESCRIPTION
In https://github.com/snyk/snyk-iac-parsers/pull/12 the tests passed randomly that one time the pipeline run but then in `main` branch they failed. The test being deleted in this PR was testing something that was never going to happen. The reason it sometimes fails and sometimes doesn't is because of the `sort.Slice` logic in the file prioritisation function - depending on the order it goes through the files, the `sort.Slice` might put random `.tfvars` files before or after valid `.tf` files.

One way to fix this would be to add a lot of `if` statements throughout the code to check if invalid variable files are provided (e.g. `test.tfvars`) but in `ParseModule` we already filter those out. I don't see the point in doing this.