### PR TITLE
fix: path separator for windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   snyk: snyk/snyk@1.1.1
+  win: circleci/windows@2.4
 
 defaults: &defaults
   working_directory: ~/snyk-iac-parsers
@@ -13,6 +14,12 @@ commands:
       - run:
           name: Build
           command: go build ./...
+  test:
+    description: Runs the regression tests
+    steps:
+      - run:
+          name: Run Golang tests
+          command: go test ./...
 
 jobs:
   lint_and_format:
@@ -37,16 +44,23 @@ jobs:
       - run:
           name: "Run gofmt"
           command: "! gofmt -d -e . | read"
-  regression-test:
+  regression-test-linux:
     <<: *defaults
     docker:
       - image: circleci/golang:1.17
     steps:
       - checkout
       - build
-      - run:
-          name: Run Golang tests
-          command: go test ./...
+      - test
+  regression-test-windows:
+    <<: *defaults
+    executor:
+      name: win/default
+      size: medium
+    steps:
+      - checkout
+      - build
+      - test
   security-oss:
     docker:
       - image: cimg/go:1.17.2 
@@ -78,5 +92,7 @@ workflows:
           name: Snyk oss
       - security-code:
           name: Snyk code
-      - regression-test:
-          name: Regression Test
+      - regression-test-linux:
+          name: Regression Test (Linux)
+      - regression-test-windows:
+          name: Regression Test (Windows)

--- a/terraform/fixtures/a.auto.tfvars
+++ b/terraform/fixtures/a.auto.tfvars
@@ -1,0 +1,4 @@
+remote_user_addr_a_auto_tfvars = ["0.0.0.0/0"]
+
+remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
+

--- a/terraform/fixtures/b.auto.tfvars
+++ b/terraform/fixtures/b.auto.tfvars
@@ -1,0 +1,1 @@
+remote_user_addr_b_auto_tfvars = ["0.0.0.0/0"]

--- a/terraform/fixtures/terraform.tfvars
+++ b/terraform/fixtures/terraform.tfvars
@@ -1,0 +1,6 @@
+remote_user_addr_terraform_tfvars = ["0.0.0.0/0"]
+
+remote_user_addr_a_auto_tfvars = ["1.2.3.4/32"]
+
+remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
+

--- a/terraform/fixtures/test.tf
+++ b/terraform/fixtures/test.tf
@@ -1,0 +1,44 @@
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr
+  }
+}
+resource "aws_security_group" "allow_ssh_terraform_tfvars" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr_terraform_tfvars
+  }
+}
+resource "aws_security_group" "allow_ssh_a_auto_tfvars" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr_a_auto_tfvars
+  }
+}
+resource "aws_security_group" "allow_ssh_b_auto_tfvars" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr_b_auto_tfvars
+  }
+}

--- a/terraform/fixtures/variables.tf
+++ b/terraform/fixtures/variables.tf
@@ -1,0 +1,16 @@
+variable "remote_user_addr" {
+  type = list(string)
+  default = ["0.0.0.0/0"]
+}
+variable "remote_user_addr_terraform_tfvars" {
+  type = list(string)
+  default = ["1.2.3.4/32"]
+}
+variable "remote_user_addr_a_auto_tfvars" {
+  type = list(string)
+  default = ["1.2.3.4/32"]
+}
+variable "remote_user_addr_b_auto_tfvars" {
+  type = list(string)
+  default = ["1.2.3.4/32"]
+}

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -1,13 +1,15 @@
 package terraform
 
 import (
+	"fmt"
+	"os"
 	"sort"
 	"strings"
 )
 
 func isTerraformTfvarsFile(fileName string) bool {
 	// the terraform.tfvars file is a strict file name so make sure the file isn't called something like *terraform.tfvars
-	return fileName == DEFAULT_TFVARS || strings.HasSuffix(fileName, "/"+DEFAULT_TFVARS)
+	return fileName == DEFAULT_TFVARS || strings.HasSuffix(fileName, fmt.Sprintf("%c%s", os.PathSeparator, DEFAULT_TFVARS))
 }
 
 func isValidVariableFile(fileName string) bool {

--- a/terraform/utils_test.go
+++ b/terraform/utils_test.go
@@ -1,30 +1,32 @@
 package terraform
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
 )
 
 func TestIsTerraformTfvarsFile(t *testing.T) {
 	assert.True(t, isTerraformTfvarsFile("terraform.tfvars"))
-	assert.True(t, isTerraformTfvarsFile("path/to/terraform.tfvars"))
+	assert.True(t, isTerraformTfvarsFile(fmt.Sprintf("path%cto%cterraform.tfvars", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isTerraformTfvarsFile("test_terraform.tfvars"))
 }
 
 func TestIsValidVariableFile(t *testing.T) {
-	assert.True(t, isValidVariableFile("path/to/terraform.tfvars"))
-	assert.False(t, isValidVariableFile("path/to/terraform.tfvars.json"))
-	assert.True(t, isValidVariableFile("path/to/test.tf"))
-	assert.True(t, isValidVariableFile("path/to/test.auto.tfvars"))
-	assert.False(t, isValidVariableFile("path/to/test.auto.tfvars.json"))
+	assert.True(t, isValidVariableFile(fmt.Sprintf("path%cto%cterraform.tfvars", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidVariableFile(fmt.Sprintf("path%cto%cterraform.tfvars.json", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidVariableFile(fmt.Sprintf("path%cto%ctest.tf", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidVariableFile(fmt.Sprintf("path%cto%ctest.auto.tfvars", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidVariableFile(fmt.Sprintf("path%cto%ctest.auto.tfvars.json", os.PathSeparator, os.PathSeparator)))
 }
 
 func TestIsValidTerraformFile(t *testing.T) {
-	assert.False(t, isValidTerraformFile("path/to/terraform.tfvars"))
-	assert.False(t, isValidTerraformFile("path/to/terraform.tfvars.json"))
-	assert.True(t, isValidTerraformFile("path/to/test.tf"))
-	assert.False(t, isValidTerraformFile("path/to/test.auto.tfvars"))
-	assert.False(t, isValidTerraformFile("path/to/test.auto.tfvars.json"))
+	assert.False(t, isValidTerraformFile(fmt.Sprintf("path%cto%cterraform.tfvars", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidTerraformFile(fmt.Sprintf("path%cto%cterraform.tfvars.json", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidTerraformFile(fmt.Sprintf("path%cto%ctest.tf", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidTerraformFile(fmt.Sprintf("path%cto%ctest.auto.tfvars", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidTerraformFile(fmt.Sprintf("path%cto%ctest.auto.tfvars.json", os.PathSeparator, os.PathSeparator)))
 }
 
 func TestOrderFilesByPriority(t *testing.T) {


### PR DESCRIPTION
The Windows acceptance tests in `snyk` started failing. It was hard to tell why so I printed the parsed files in a branch and I could see from the output of the failing test that the file names use `\\` instead of `/`, which is used as a condition in our code to parse `terraform.tfvars` files: https://app.circleci.com/pipelines/github/snyk/snyk/10160/workflows/cca75d6f-b978-4bca-a934-09b0b0a9b7f2/jobs/78772

This PR adds a step to CircleCI to run Windows tests, modifies one of the tests to read from the filesystem and so mimic the `snyk` behaviour, and fixes the issue by using `os.PathSeparator` instead of `/`.

The added fixture files are just a copy-paste of the inline tests.