### PR TITLE
fix: tfvars path windows replace

### DIFF
--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -2,14 +2,15 @@ package terraform
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 )
 
+// the terraform.tfvars file is a strict file name so make sure the file isn't called something like *terraform.tfvars
 func isTerraformTfvarsFile(fileName string) bool {
-	// the terraform.tfvars file is a strict file name so make sure the file isn't called something like *terraform.tfvars
-	return fileName == DEFAULT_TFVARS || strings.HasSuffix(fileName, fmt.Sprintf("%c%s", os.PathSeparator, DEFAULT_TFVARS))
+	// the CLI uses this library by compiling it through gopherjs for Linux so for Windows we must remove backward slashes
+	osFileName := strings.Replace(fileName, "\\", "/", -1)
+	return fileName == DEFAULT_TFVARS || strings.HasSuffix(osFileName, fmt.Sprintf("/%s", DEFAULT_TFVARS))
 }
 
 func isValidVariableFile(fileName string) bool {

--- a/terraform/utils_test.go
+++ b/terraform/utils_test.go
@@ -11,6 +11,7 @@ func TestIsTerraformTfvarsFile(t *testing.T) {
 	assert.True(t, isTerraformTfvarsFile("terraform.tfvars"))
 	assert.True(t, isTerraformTfvarsFile(fmt.Sprintf("path%cto%cterraform.tfvars", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isTerraformTfvarsFile("test_terraform.tfvars"))
+	assert.True(t, isTerraformTfvarsFile("C:\\\\path\\\\to\\\\terraform.tfvars"))
 }
 
 func TestIsValidVariableFile(t *testing.T) {


### PR DESCRIPTION
In https://github.com/snyk/snyk-iac-parsers/pull/14 I tried to fix an issue where file paths from Windows scans (looking like `C:\\\\Users\\\\circleci\\\\snyk\\\\test\\\\fixtures\\\\iac\\\\terraform\\\\var_deref\\\\terraform.tfvars`) wouldn't identify the `terraform.tfvars` file as valid because we were always trying to find a file with the suffix `/terraform.tfvars`.

I added a Windows test which exemplified the problem but I hadn't tested it with the CLI directly and so I didn't realise that it wouldn't actually fix it. The reason it doesn't fix it is because we use `gopherjs` to compile the code to JavaScript, with `GOOS=linux`: https://github.com/snyk/snyk/blob/master/release-scripts/hcl-to-json-parser-generator-v2/Makefile#L33

As [this](https://curatedgo.com/r/gopherjs-a-gopherjsgopherjs/index.html) says, the generated code would be for the platform you configured via `GOOS` so although we were using `os.PathSeparator`, it was defaulting to `/` (the Linux version). Then the `gopherjs` generated code would run in Windows and we end up in the same situation.

One way to fix this would be to have two compilation steps for `gopherjs`, one for Windows and one for Linux. We can try exploring that but in the meantime I am doing a quick fix by replacing `\` with `/` in the provided file path. I've actually tested it with the CLI this time and it works: https://app.circleci.com/pipelines/github/snyk/snyk/10192/workflows/26782fdb-04a8-497c-9931-b2756dd6494e