### PR TITLE
chore: add service catalog to the repository [CFG-1593]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,19 @@
+# Documentation: https://www.notion.so/snyk/Entity-Metadata-1e313ca03f954a6680b2b6b7b3d95297
+# Validation Tool: https://github.com/snyk/prodsec-github-bot
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: snyk-iac-parsers
+  annotations:
+    github.com/project-slug: snyk/snyk-iac-parsers
+    circleci.com/project-slug: github/snyk/snyk-iac-parsers
+  description: <
+    A Golang library that exposes functions for parsing YAML, HCL2, Terraform (including variable dereferencing) and Terraform Plan (JSON) files.
+  labels:
+    snyk.io/businessCriticality: medium
+    snyk.io/visibility: public
+    snyk.io/metadata-version: "2022-23-01"
+spec:
+  type: library
+  lifecycle: production
+  owner: "group-infrastructure-as-code"


### PR DESCRIPTION
Used by the Snyk organization via backstage.io to manage our service catalog. 

- the `metadata.labels["snyk.io/businessCriticality"]` was set to `medium` because this is used by the SCM and CLI so it could affect the responses given to customers there, but it doesn't stop us doing business (open to discussion)
- the `metadata.labels["snyk.io/metadata-version"]` was set based on the validation tool
- the `spec.owner` was  set based on  the validation tool

Validation using https://github.com/snyk/prodsec-github-bot:
![Screenshot 2022-02-24 at 15 32 35](https://user-images.githubusercontent.com/81559517/155556745-7797e15c-01bf-4786-8ada-12ef24fab62a.png)

Ticket: https://snyksec.atlassian.net/browse/CFG-1593
