### PR TITLE
chore: use circle context for env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,12 @@ workflows:
           name: Lint & formatting
       - security-oss:
           name: Snyk oss
+          context:
+            - snyk-iac-seceng
       - security-code:
           name: Snyk code
+          context:
+            - snyk-iac-seceng
       - regression-test-linux:
           name: Regression Test (Linux)
       - regression-test-windows:


### PR DESCRIPTION
For https://snyksec.atlassian.net/browse/CFG-1594 I was checking that we had the security scanning configured for this repo by comparing its CircleCI setup with the one in `snyk-iac-rules`. So this PR does whatever this PR did: https://github.com/snyk/snyk-iac-rules/pull/120