### PR TITLE
Feat: Add TF locals support [CFG-1500]

### DIFF
--- a/terraform/hcl2json.go
+++ b/terraform/hcl2json.go
@@ -150,7 +150,7 @@ func extractModuleVariables(files map[string]File, parseRes *ParseModuleResult) 
 	localsMap := ValueMap{}
 
 	for fileName, file := range files {
-		if _, ok := parseRes.failedFiles[fileName]; !ok && isValidLocalsFile(fileName) {
+		if _, ok := parseRes.failedFiles[fileName]; !ok && isValidTerraformFile(fileName) {
 			res, err := extractLocals(file, inputsMap)
 			if err != nil {
 				// skip non-user errors

--- a/terraform/hcl2json.go
+++ b/terraform/hcl2json.go
@@ -52,8 +52,8 @@ var extractInputVariables = func(file File) (ValueMap, error) {
 }
 
 // extractLocals extracts the input values from the provided file
-var extractLocals = func(file File) (ValueMap, error) {
-	localsMap, diagnostics := extractLocalsFromFile(file)
+var extractLocals = func(file File, inputsMap ValueMap) (ValueMap, error) {
+	localsMap, diagnostics := extractLocalsFromFile(file, inputsMap)
 	if diagnostics.HasErrors() {
 		return ValueMap{}, createInvalidHCLError(diagnostics.Errs())
 	}
@@ -151,7 +151,7 @@ func extractModuleVariables(files map[string]File, parseRes *ParseModuleResult) 
 
 	for fileName, file := range files {
 		if _, ok := parseRes.failedFiles[fileName]; !ok && isValidLocalsFile(fileName) {
-			res, err := extractLocals(file)
+			res, err := extractLocals(file, inputsMap)
 			if err != nil {
 				// skip non-user errors
 				if isUserError(err) {

--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -32,14 +32,18 @@ type NewParserParams struct {
 
 type JSON = map[string]interface{}
 
+func NewParserVariables(variables ModuleVariables) ValueMap {
+	return ValueMap{
+		"var":   cty.ObjectVal(variables.inputs),
+		"local": cty.ObjectVal(variables.locals),
+	}
+}
+
 func NewParser(params NewParserParams) Parser {
 	return Parser{
-		bytes: params.bytes,
-		variables: ValueMap{
-			"var":   cty.ObjectVal(params.variables.inputs),
-			"local": cty.ObjectVal(params.variables.locals),
-		},
-		options: params.options,
+		bytes:     params.bytes,
+		variables: NewParserVariables(params.variables),
+		options:   params.options,
 	}
 }
 

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -14,3 +14,11 @@ var tfFileVariableSchema = &hcl.BodySchema{
 		},
 	},
 }
+
+var tfFileLocalSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type: "locals",
+		},
+	},
+}

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -25,6 +25,15 @@ func isValidInputVariablesFile(fileName string) bool {
 	return false
 }
 
+func isValidLocalsFile(fileName string) bool {
+	for _, fileExt := range VALID_TERRAFORM_FILES {
+		if strings.HasSuffix(fileName, fileExt) {
+			return true
+		}
+	}
+	return false
+}
+
 func isValidTerraformFile(fileName string) bool {
 	for _, fileExt := range VALID_TERRAFORM_FILES {
 		if strings.HasSuffix(fileName, fileExt) {

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -25,15 +25,6 @@ func isValidInputVariablesFile(fileName string) bool {
 	return false
 }
 
-func isValidLocalsFile(fileName string) bool {
-	for _, fileExt := range VALID_TERRAFORM_FILES {
-		if strings.HasSuffix(fileName, fileExt) {
-			return true
-		}
-	}
-	return false
-}
-
 func isValidTerraformFile(fileName string) bool {
 	for _, fileExt := range VALID_TERRAFORM_FILES {
 		if strings.HasSuffix(fileName, fileExt) {

--- a/terraform/variables.go
+++ b/terraform/variables.go
@@ -34,6 +34,19 @@ func extractInputVariablesFromFile(file File) (ValueMap, hcl.Diagnostics) {
 	return inputVariables, hclDiags
 }
 
+func extractLocalsFromFile(file File) (ValueMap, hcl.Diagnostics) {
+	var localsMap ValueMap
+	var hclDiags hcl.Diagnostics
+
+	localsMap, hclDiags = extractLocalsFromTfFile(file)
+
+	if hclDiags.HasErrors() {
+		return localsMap, hclDiags
+	}
+
+	return localsMap, hclDiags
+}
+
 // Logic inspired from https://github.com/hashicorp/terraform/blob/f266d1ee82d1fa4d882c146cc131fec4bef753cf/internal/configs/named_values.go#L113
 func extractInputVariablesFromTfFile(file *hcl.File) (ValueMap, hcl.Diagnostics) {
 	inputVariablesMap := ValueMap{}
@@ -94,4 +107,27 @@ func mergeInputVariables(inputVariablesByFile InputVariablesByFile) ValueMap {
 	}
 
 	return combinedInputVariables
+}
+
+// Logic inspired from https://github.com/hashicorp/terraform/blob/f266d1ee82d1fa4d882c146cc131fec4bef753cf/internal/configs/named_values.go#L113
+func extractLocalsFromTfFile(file File) (ValueMap, hcl.Diagnostics) {
+	localsMap := ValueMap{}
+
+	bodyContent, _, hclDiags := file.hclFile.Body.PartialContent(tfFileLocalSchema)
+	if hclDiags.HasErrors() {
+		return localsMap, hclDiags
+	}
+
+	for _, block := range bodyContent.Blocks {
+		attrs, _ := block.Body.JustAttributes()
+		for localName, attr := range attrs {
+			localVal, diags := attr.Expr.Value(&hcl.EvalContext{Functions: terraformFunctions})
+			if diags.HasErrors() || localVal.IsNull() {
+				continue
+			}
+			localsMap[localName] = localVal
+		}
+	}
+
+	return localsMap, hclDiags
 }


### PR DESCRIPTION
### What this does
- Adds support for dereferencing local variables during parsing, including:
    - Expressions evaluation during the dereferencing.
    - Correctly evaluate locals with input values references.
    - Correctly evaluate locals with other local values references.

### Background context

We would like to start supporting reading variable values in Terraform files. This is to help on our vision to create better TF support for our product and find more issues that might have been ignored so far because they would be coming from variable values. This PR is for adding support for local values.

### More information

- [CFG-1500](https://snyksec.atlassian.net/browse/CFG-1500)
- [Terraform - Local values](https://www.terraform.io/language/values/locals)