### PR TITLE
Refactor: Rename variables to inputs [CFG-1500]

### DIFF
--- a/scripts/opa/main.go
+++ b/scripts/opa/main.go
@@ -35,7 +35,7 @@ func runOpa() {
 				return nil, err
 			}
 
-			input, err := terraform.ParseHclToJson(filePath, string(content), terraform.VariableMap{})
+			input, err := terraform.ParseHclToJson(filePath, string(content), terraform.ModuleVariables{})
 			if err != nil {
 				return nil, err
 			}

--- a/terraform/hcl2json.go
+++ b/terraform/hcl2json.go
@@ -14,15 +14,15 @@ func ParseModule(files map[string]interface{}) map[string]interface{} {
 	parsedFiles := make(map[string]interface{})
 	debugLogs := make(map[string]interface{})
 
-	inputsByFile := InputsByFile{}
+	inputVariablesByFile := InputVariablesByFile{}
 	for fileName, fileContentInterface := range files {
-		if isValidInputsFile(fileName) {
+		if isValidInputVariablesFile(fileName) {
 			// need to use interface{} for gopherjs, so cast it back to string
 			fileContent, ok := fileContentInterface.(string)
 			if !ok {
 				continue
 			}
-			inputsMap, err := extractInputs(fileName, fileContent)
+			inputVariablesMap, err := extractInputVariables(fileName, fileContent)
 			if err != nil {
 				// skip non-user errors
 				if isUserError(err) {
@@ -31,15 +31,15 @@ func ParseModule(files map[string]interface{}) map[string]interface{} {
 				}
 				continue
 			}
-			inputsByFile[fileName] = inputsMap
+			inputVariablesByFile[fileName] = inputVariablesMap
 		}
 	}
 
 	// merge inputs so they can be used across multiple files
-	inputsMap := mergeInputs(inputsByFile)
+	inputVariablesMap := mergeInputVariables(inputVariablesByFile)
 
 	vars := ModuleVariables{
-		inputs: inputsMap,
+		inputs: inputVariablesMap,
 	}
 
 	for fileName, fileContent := range files {
@@ -65,19 +65,19 @@ func ParseModule(files map[string]interface{}) map[string]interface{} {
 	}
 }
 
-// extractInputs extracts the input values from the provided file
-var extractInputs = func(fileName string, fileContent string) (ValueMap, error) {
+// extractInputVariables extracts the input variables values from the provided file
+var extractInputVariables = func(fileName string, fileContent string) (ValueMap, error) {
 	file, diagnostics := hclsyntax.ParseConfig([]byte(fileContent), fileName, hcl.Pos{Line: 1, Column: 1})
 	if diagnostics.HasErrors() {
 		return ValueMap{}, createInvalidHCLError(diagnostics.Errs())
 	}
 
-	fileInputsMap, diagnostics := extractInputsFromFile(fileName, file)
+	fileInputVariablesMap, diagnostics := extractInputVariablesFromFile(fileName, file)
 	if diagnostics.HasErrors() {
 		return ValueMap{}, createInvalidHCLError(diagnostics.Errs())
 	}
 
-	return fileInputsMap, nil
+	return fileInputVariablesMap, nil
 }
 
 // ParseHclToJson parses a provided HCL file to JSON and dereferences any known variables using the provided variables

--- a/terraform/hcl2json_test.go
+++ b/terraform/hcl2json_test.go
@@ -16,7 +16,7 @@ func TestParseHCL2JSONSuccess(t *testing.T) {
 	type test struct {
 		name      string
 		input     string
-		variables VariableMap
+		variables ModuleVariables
 		expected  string
 	}
 
@@ -367,10 +367,10 @@ variable "region" {
 		}
 	}
 }`,
-			variables: VariableMap{
-				"var": cty.ObjectVal(VariableMap{
+			variables: ModuleVariables{
+				inputs: ValueMap{
 					"instance_name": cty.StringVal("test"),
-				}),
+				},
 			},
 		},
 		{
@@ -397,10 +397,10 @@ variable "region" {
 		}
 	}
 }`,
-			variables: VariableMap{
-				"local": cty.ObjectVal(VariableMap{
+			variables: ModuleVariables{
+				locals: ValueMap{
 					"instance_name": cty.StringVal("test"),
-				}),
+				},
 			},
 		},
 		{
@@ -418,10 +418,10 @@ variable "region" {
 		}
 	}
 }`,
-			variables: VariableMap{
-				"local": cty.ObjectVal(VariableMap{
+			variables: ModuleVariables{
+				locals: ValueMap{
 					"instance_name": cty.StringVal("test"),
-				}),
+				},
 			},
 		},
 		{
@@ -435,10 +435,10 @@ variable "region" {
 		"test": "test"
 	}
 }`,
-			variables: VariableMap{
-				"local": cty.ObjectVal(VariableMap{
+			variables: ModuleVariables{
+				locals: ValueMap{
 					"instance_name": cty.StringVal("test"),
-				}),
+				},
 			},
 		},
 		{
@@ -460,11 +460,11 @@ locals {
 		}
 	}
 }`,
-			variables: VariableMap{
-				"local": cty.ObjectVal(VariableMap{
+			variables: ModuleVariables{
+				locals: ValueMap{
 					"test1": cty.StringVal("a"),
 					"test2": cty.StringVal("b"),
-				}),
+				},
 			},
 		},
 		{
@@ -491,10 +491,10 @@ locals {
 		}
 	}
 }`,
-			variables: VariableMap{
-				"var": cty.ObjectVal(VariableMap{
+			variables: ModuleVariables{
+				inputs: ValueMap{
 					"wrong_name": cty.StringVal("test"),
-				}),
+				},
 			},
 		},
 	}
@@ -527,7 +527,7 @@ block "label_one" {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := ParseHclToJson("test", tc.input, nil)
+			_, err := ParseHclToJson("test", tc.input, ModuleVariables{})
 			require.NotNil(t, err)
 			assert.Equal(t, tc.expected, err.Error())
 			assert.True(t, isUserError(err))
@@ -535,7 +535,7 @@ block "label_one" {
 	}
 }
 
-func TestExtractVariablesSuccess(t *testing.T) {
+func TestExtractInputsSuccess(t *testing.T) {
 	type TestInput struct {
 		fileName    string
 		fileContent string
@@ -544,7 +544,7 @@ func TestExtractVariablesSuccess(t *testing.T) {
 	type test struct {
 		name     string
 		input    TestInput
-		expected VariableMap
+		expected ValueMap
 	}
 	tests := []test{
 		{
@@ -556,12 +556,7 @@ func TestExtractVariablesSuccess(t *testing.T) {
 					type = "string"
 				}`,
 			},
-			expected: VariableMap{
-				"var": cty.ObjectVal(VariableMap{}),
-				"local": cty.ObjectVal(VariableMap{
-					"dummy": cty.StringVal("dummy"),
-				}),
-			},
+			expected: ValueMap{},
 		},
 		{
 			name: "Simple variable block with default",
@@ -573,13 +568,8 @@ func TestExtractVariablesSuccess(t *testing.T) {
 					default = "test"
 				}`,
 			},
-			expected: VariableMap{
-				"var": cty.ObjectVal(VariableMap{
-					"test": cty.StringVal("test"),
-				}),
-				"local": cty.ObjectVal(VariableMap{
-					"dummy": cty.StringVal("dummy"),
-				}),
+			expected: ValueMap{
+				"test": cty.StringVal("test"),
 			},
 		},
 		{
@@ -592,12 +582,7 @@ func TestExtractVariablesSuccess(t *testing.T) {
 					default = null
 				}`,
 			},
-			expected: VariableMap{
-				"var": cty.ObjectVal(VariableMap{}),
-				"local": cty.ObjectVal(VariableMap{
-					"dummy": cty.StringVal("dummy"),
-				}),
-			},
+			expected: ValueMap{},
 		},
 		{
 			name: "Two variable one with null value and the other with valid value",
@@ -614,13 +599,8 @@ func TestExtractVariablesSuccess(t *testing.T) {
 					default = "test"
 				}`,
 			},
-			expected: VariableMap{
-				"var": cty.ObjectVal(VariableMap{
-					"test": cty.StringVal("test"),
-				}),
-				"local": cty.ObjectVal(VariableMap{
-					"dummy": cty.StringVal("dummy"),
-				}),
+			expected: ValueMap{
+				"test": cty.StringVal("test"),
 			},
 		},
 		{
@@ -633,18 +613,13 @@ func TestExtractVariablesSuccess(t *testing.T) {
 					default  = "us-central1"
 				}`,
 			},
-			expected: VariableMap{
-				"var": cty.ObjectVal(VariableMap{}),
-				"local": cty.ObjectVal(VariableMap{
-					"dummy": cty.StringVal("dummy"),
-				}),
-			},
+			expected: ValueMap{},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := extractVariables(tc.input.fileName, tc.input.fileContent)
+			actual, err := extractInputs(tc.input.fileName, tc.input.fileContent)
 			require.Nil(t, err)
 			assert.Equal(t, tc.expected, actual)
 		})
@@ -960,7 +935,7 @@ variable "dummy" {
 				defer func() {
 					parseHclToJson = oldParseHclToJson
 				}()
-				parseHclToJson = func(fileName string, fileContent string, variableMap VariableMap) (string, error) {
+				parseHclToJson = func(fileName string, fileContent string, variableMap ModuleVariables) (string, error) {
 					if fileName == "fail.tf" {
 						return "", tc.parseErr
 					}
@@ -968,15 +943,15 @@ variable "dummy" {
 				}
 			}
 			if tc.extractErr != nil {
-				oldExtractVariables := extractVariables
+				oldExtractInputs := extractInputs
 				defer func() {
-					extractVariables = oldExtractVariables
+					extractInputs = oldExtractInputs
 				}()
-				extractVariables = func(fileName string, fileContent string) (VariableMap, error) {
+				extractInputs = func(fileName string, fileContent string) (ValueMap, error) {
 					if fileName == "fail.tf" {
 						return nil, tc.extractErr
 					}
-					return oldExtractVariables(fileName, fileContent)
+					return oldExtractInputs(fileName, fileContent)
 				}
 			}
 			actual := ParseModule(tc.files)

--- a/terraform/hcl2json_test.go
+++ b/terraform/hcl2json_test.go
@@ -619,7 +619,7 @@ func TestExtractInputsSuccess(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := extractInputs(tc.input.fileName, tc.input.fileContent)
+			actual, err := extractInputVariables(tc.input.fileName, tc.input.fileContent)
 			require.Nil(t, err)
 			assert.Equal(t, tc.expected, actual)
 		})
@@ -943,15 +943,15 @@ variable "dummy" {
 				}
 			}
 			if tc.extractErr != nil {
-				oldExtractInputs := extractInputs
+				oldExtractInputVariables := extractInputVariables
 				defer func() {
-					extractInputs = oldExtractInputs
+					extractInputVariables = oldExtractInputVariables
 				}()
-				extractInputs = func(fileName string, fileContent string) (ValueMap, error) {
+				extractInputVariables = func(fileName string, fileContent string) (ValueMap, error) {
 					if fileName == "fail.tf" {
 						return nil, tc.extractErr
 					}
-					return oldExtractInputs(fileName, fileContent)
+					return oldExtractInputVariables(fileName, fileContent)
 				}
 			}
 			actual := ParseModule(tc.files)

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -13,7 +13,7 @@ func isTerraformTfvarsFile(fileName string) bool {
 	return fileName == DEFAULT_TFVARS || strings.HasSuffix(osFileName, fmt.Sprintf("/%s", DEFAULT_TFVARS))
 }
 
-func isValidVariableFile(fileName string) bool {
+func isValidInputsFile(fileName string) bool {
 	if isTerraformTfvarsFile(fileName) {
 		return true
 	}

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -13,7 +13,7 @@ func isTerraformTfvarsFile(fileName string) bool {
 	return fileName == DEFAULT_TFVARS || strings.HasSuffix(osFileName, fmt.Sprintf("/%s", DEFAULT_TFVARS))
 }
 
-func isValidInputsFile(fileName string) bool {
+func isValidInputVariablesFile(fileName string) bool {
 	if isTerraformTfvarsFile(fileName) {
 		return true
 	}

--- a/terraform/utils_test.go
+++ b/terraform/utils_test.go
@@ -2,9 +2,10 @@ package terraform
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsTerraformTfvarsFile(t *testing.T) {
@@ -15,11 +16,11 @@ func TestIsTerraformTfvarsFile(t *testing.T) {
 }
 
 func TestIsValidVariableFile(t *testing.T) {
-	assert.True(t, isValidVariableFile(fmt.Sprintf("path%cto%cterraform.tfvars", os.PathSeparator, os.PathSeparator)))
-	assert.False(t, isValidVariableFile(fmt.Sprintf("path%cto%cterraform.tfvars.json", os.PathSeparator, os.PathSeparator)))
-	assert.True(t, isValidVariableFile(fmt.Sprintf("path%cto%ctest.tf", os.PathSeparator, os.PathSeparator)))
-	assert.True(t, isValidVariableFile(fmt.Sprintf("path%cto%ctest.auto.tfvars", os.PathSeparator, os.PathSeparator)))
-	assert.False(t, isValidVariableFile(fmt.Sprintf("path%cto%ctest.auto.tfvars.json", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidInputsFile(fmt.Sprintf("path%cto%cterraform.tfvars", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidInputsFile(fmt.Sprintf("path%cto%cterraform.tfvars.json", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidInputsFile(fmt.Sprintf("path%cto%ctest.tf", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidInputsFile(fmt.Sprintf("path%cto%ctest.auto.tfvars", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidInputsFile(fmt.Sprintf("path%cto%ctest.auto.tfvars.json", os.PathSeparator, os.PathSeparator)))
 }
 
 func TestIsValidTerraformFile(t *testing.T) {

--- a/terraform/utils_test.go
+++ b/terraform/utils_test.go
@@ -16,11 +16,11 @@ func TestIsTerraformTfvarsFile(t *testing.T) {
 }
 
 func TestIsValidVariableFile(t *testing.T) {
-	assert.True(t, isValidInputsFile(fmt.Sprintf("path%cto%cterraform.tfvars", os.PathSeparator, os.PathSeparator)))
-	assert.False(t, isValidInputsFile(fmt.Sprintf("path%cto%cterraform.tfvars.json", os.PathSeparator, os.PathSeparator)))
-	assert.True(t, isValidInputsFile(fmt.Sprintf("path%cto%ctest.tf", os.PathSeparator, os.PathSeparator)))
-	assert.True(t, isValidInputsFile(fmt.Sprintf("path%cto%ctest.auto.tfvars", os.PathSeparator, os.PathSeparator)))
-	assert.False(t, isValidInputsFile(fmt.Sprintf("path%cto%ctest.auto.tfvars.json", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidInputVariablesFile(fmt.Sprintf("path%cto%cterraform.tfvars", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidInputVariablesFile(fmt.Sprintf("path%cto%cterraform.tfvars.json", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidInputVariablesFile(fmt.Sprintf("path%cto%ctest.tf", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isValidInputVariablesFile(fmt.Sprintf("path%cto%ctest.auto.tfvars", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isValidInputVariablesFile(fmt.Sprintf("path%cto%ctest.auto.tfvars.json", os.PathSeparator, os.PathSeparator)))
 }
 
 func TestIsValidTerraformFile(t *testing.T) {

--- a/terraform/variables_test.go
+++ b/terraform/variables_test.go
@@ -26,12 +26,12 @@ func TestMergeVariablesFromTerraformFiles(t *testing.T) {
 		"var2": cty.StringVal("val2-duplicate"),
 		"var3": cty.StringVal("val3"),
 	}
-	actual := mergeInputs(input)
+	actual := mergeInputVariables(input)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeVariablesOverridesWithTerraformTfvars(t *testing.T) {
-	input := InputsByFile{
+	input := InputVariablesByFile{
 		"test1.tf": ValueMap{
 			"var": cty.StringVal("val1"),
 		},
@@ -42,12 +42,12 @@ func TestMergeVariablesOverridesWithTerraformTfvars(t *testing.T) {
 	expected := ValueMap{
 		"var": cty.StringVal("val2"),
 	}
-	actual := mergeInputs(input)
+	actual := mergeInputVariables(input)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeVariablesOverridesWithAnyAutoTfvars(t *testing.T) {
-	input := InputsByFile{
+	input := InputVariablesByFile{
 		"test1.tf": ValueMap{
 			"var": cty.StringVal("val1"),
 		},
@@ -61,12 +61,12 @@ func TestMergeVariablesOverridesWithAnyAutoTfvars(t *testing.T) {
 	expected := ValueMap{
 		"var": cty.StringVal("val3"),
 	}
-	actual := mergeInputs(input)
+	actual := mergeInputVariables(input)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeVariablesOverridesWithLexicalOrderAutoTfvars(t *testing.T) {
-	input := InputsByFile{
+	input := InputVariablesByFile{
 		"test1.tf": ValueMap{
 			"var": cty.StringVal("val1"),
 		},
@@ -83,6 +83,6 @@ func TestMergeVariablesOverridesWithLexicalOrderAutoTfvars(t *testing.T) {
 	expected := ValueMap{
 		"var": cty.StringVal("val3"),
 	}
-	actual := mergeInputs(input)
+	actual := mergeInputVariables(input)
 	assert.Equal(t, expected, actual)
 }

--- a/terraform/variables_test.go
+++ b/terraform/variables_test.go
@@ -1,115 +1,88 @@
 package terraform
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/zclconf/go-cty/cty"
-	"testing"
 )
 
 func TestMergeVariablesFromTerraformFiles(t *testing.T) {
-	input := map[string]VariableMap{
-		"test1.tf": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var1": cty.StringVal("val1"),
-			}),
-		},
-		"test2.tf": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var2": cty.StringVal("val2"),
-				"var3": cty.StringVal("val3"),
-			}),
-		},
-		"test3.tf": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var2": cty.StringVal("val2-duplicate"),
-			}),
-		},
-		"test4.tf": VariableMap{
-			"var": cty.ObjectVal(VariableMap{}),
-		},
-	}
-	expected := VariableMap{
-		"var": cty.ObjectVal(VariableMap{
+	input := map[string]ValueMap{
+		"test1.tf": ValueMap{
 			"var1": cty.StringVal("val1"),
-			"var2": cty.StringVal("val2-duplicate"),
+		},
+		"test2.tf": ValueMap{
+			"var2": cty.StringVal("val2"),
 			"var3": cty.StringVal("val3"),
-		}),
+		},
+		"test3.tf": ValueMap{
+			"var2": cty.StringVal("val2-duplicate"),
+		},
+		"test4.tf": ValueMap{},
 	}
-	actual := mergeVariables(input)
+	expected := ValueMap{
+		"var1": cty.StringVal("val1"),
+		"var2": cty.StringVal("val2-duplicate"),
+		"var3": cty.StringVal("val3"),
+	}
+	actual := mergeInputs(input)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeVariablesOverridesWithTerraformTfvars(t *testing.T) {
-	input := map[string]VariableMap{
-		"test1.tf": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val1"),
-			}),
+	input := InputsByFile{
+		"test1.tf": ValueMap{
+			"var": cty.StringVal("val1"),
 		},
-		"terraform.tfvars": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val2")}),
-		},
-	}
-	expected := VariableMap{
-		"var": cty.ObjectVal(VariableMap{
+		"terraform.tfvars": ValueMap{
 			"var": cty.StringVal("val2"),
-		}),
+		},
 	}
-	actual := mergeVariables(input)
+	expected := ValueMap{
+		"var": cty.StringVal("val2"),
+	}
+	actual := mergeInputs(input)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeVariablesOverridesWithAnyAutoTfvars(t *testing.T) {
-	input := map[string]VariableMap{
-		"test1.tf": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val1"),
-			}),
+	input := InputsByFile{
+		"test1.tf": ValueMap{
+			"var": cty.StringVal("val1"),
 		},
-		"terraform.tfvars": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val2")}),
+		"terraform.tfvars": ValueMap{
+			"var": cty.StringVal("val2"),
 		},
-		"test.auto.tfvars": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val3")}),
-		},
-	}
-	expected := VariableMap{
-		"var": cty.ObjectVal(VariableMap{
+		"test.auto.tfvars": ValueMap{
 			"var": cty.StringVal("val3"),
-		}),
+		},
 	}
-	actual := mergeVariables(input)
+	expected := ValueMap{
+		"var": cty.StringVal("val3"),
+	}
+	actual := mergeInputs(input)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMergeVariablesOverridesWithLexicalOrderAutoTfvars(t *testing.T) {
-	input := map[string]VariableMap{
-		"test1.tf": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val1"),
-			}),
+	input := InputsByFile{
+		"test1.tf": ValueMap{
+			"var": cty.StringVal("val1"),
 		},
-		"terraform.tfvars": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val2")}),
+		"terraform.tfvars": ValueMap{
+			"var": cty.StringVal("val2"),
 		},
-		"test.auto.tfvars": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val3")}),
-		},
-		"a_test.auto.tfvars": VariableMap{
-			"var": cty.ObjectVal(VariableMap{
-				"var": cty.StringVal("val4")}),
-		},
-	}
-	expected := VariableMap{
-		"var": cty.ObjectVal(VariableMap{
+		"test.auto.tfvars": ValueMap{
 			"var": cty.StringVal("val3"),
-		}),
+		},
+		"a_test.auto.tfvars": ValueMap{
+			"var": cty.StringVal("val4"),
+		},
 	}
-	actual := mergeVariables(input)
+	expected := ValueMap{
+		"var": cty.StringVal("val3"),
+	}
+	actual := mergeInputs(input)
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
### What this does

- Refactors types for storing input values, local values, and TF variables in the `terraform` package.
This change helps clarify the contents of different variable-related structs and maps in our current parser's flow.
- Renames several functions and types with the `variable` term, to use the term `input` instead.
This change helps gain better distinguishment between inputs and locals in the code, as both are considered variables in Terraform.

### More information

- [CFG-1500](https://snyksec.atlassian.net/browse/CFG-1500)