### PR TITLE
Refactor: Extract `ParseModule` flow steps to functions [CFG-1500]

### DIFF
--- a/terraform/variables.go
+++ b/terraform/variables.go
@@ -18,13 +18,13 @@ type ParserVariables map[string]ValueMap
 
 type InputVariablesByFile map[string]ValueMap
 
-func extractInputVariablesFromFile(fileName string, file *hcl.File) (ValueMap, hcl.Diagnostics) {
+func extractInputVariablesFromFile(file File) (ValueMap, hcl.Diagnostics) {
 	var inputVariables ValueMap
 	var hclDiags hcl.Diagnostics
-	if strings.HasSuffix(fileName, TF) {
-		inputVariables, hclDiags = extractInputVariablesFromTfFile(file)
-	} else if strings.HasSuffix(fileName, TFVARS) {
-		inputVariables, hclDiags = extractInputVariablesFromTfvarsFile(file)
+	if strings.HasSuffix(file.fileName, TF) {
+		inputVariables, hclDiags = extractInputVariablesFromTfFile(file.hclFile)
+	} else if strings.HasSuffix(file.fileName, TFVARS) {
+		inputVariables, hclDiags = extractInputVariablesFromTfvarsFile(file.hclFile)
 	}
 
 	if hclDiags.HasErrors() {


### PR DESCRIPTION
### What this does

- Extracts the flow steps of the `ParseModule` into separate functions.
- Adds struct types for files and the parser result.
- Instead of the `hclsyntax.ParseConfig` function getting called for each step, it is now called once at the beginning of the flow.

### More information

- [CFG-1500](https://snyksec.atlassian.net/browse/CFG-1500)