### PR TITLE
feat: Support for locals referencing locals [CFG-1654]

### DIFF
--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -1,0 +1,532 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestParseHCL2JSONSuccess(t *testing.T) {
+	type test struct {
+		name      string
+		input     string
+		variables ModuleVariables
+		expected  string
+	}
+
+	tests := []test{
+		{
+			name: "Nested block inside a labelled block",
+			input: `
+block "label_one" "label_two" {
+	nested_block { }
+}`,
+			expected: `{
+	"block": {
+		"label_one": {
+			"label_two": {
+				"nested_block": {}
+			}
+		}
+	}
+}`,
+		},
+		{
+			name: "Two simple blocks",
+			input: `
+block "label_one" {
+}
+block "label_one" {
+}
+`,
+			expected: `{
+	"block": {
+		"label_one": [
+			{},
+			{}
+		]
+	}
+}`,
+		},
+		{
+			name: "Block with multiple labels and no attributes",
+			input: `
+resource "test1" "test2" {
+}
+
+resource "test1" "test3" {
+}
+`,
+			expected: `{
+	"resource": {
+		"test1": {
+			"test2": {},
+			"test3": {}
+		}
+	}
+}`,
+		},
+		{
+			name: "Block with a literal value attribute",
+			input: `
+block "label_one" {
+	attribute = "value"
+}`,
+			expected: `{
+	"block": {
+		"label_one": {
+			"attribute": "value"
+		}
+	}
+}`,
+		},
+		{
+			name: "Block with a unary operation expression attribute",
+			input: `
+block "label_one" {
+	attribute = -1
+}`,
+			expected: `{
+	"block": {
+		"label_one": {
+			"attribute": -1
+		}
+	}
+}`,
+		},
+		{
+			name: "Block with a template expression attribute",
+			input: `
+block "label_one" {
+	attribute = "${1 + 2}"
+}`,
+			expected: `{
+	"block": {
+		"label_one": {
+			"attribute": 3
+		}
+	}
+}`,
+		},
+		{
+			name: "Block with a template expression attribute with a for loop wrapped in a string",
+			input: `
+block "label_one" {
+	attribute = "This has a for loop: %{for x in [1, 2, 3]}${x},%{endfor}"
+}`,
+			expected: `{
+	"block": {
+		"label_one": {
+			"attribute": "This has a for loop: 1,2,3,"
+		}
+	}
+}`,
+		},
+		{
+			name: "Block with a template expression attribute with an if statement wrapped in a string",
+			input: `
+block "label_one" {
+	attribute = "This has an if statement: %{ if true }true%{ else }false%{ endif }"
+}`,
+			expected: `{
+	"block": {
+		"label_one": {
+			"attribute": "This has an if statement: true"
+		}
+	}
+}`,
+		},
+		{
+			name: "Block with a conditional expression",
+			input: `
+block "label_one" {
+	attribute = true ? "true" : "false"
+}`,
+			expected: `{
+	"block": {
+		"label_one": {
+			"attribute": "true"
+		}
+	}
+}`,
+		},
+		{
+			name: "Block with a for expression attribute",
+			input: `locals {
+	thing = [for x in [1, 2, 3]: x * 2]
+}`,
+			expected: `{
+	"locals": {
+		"thing": [
+			2,
+			4,
+			6
+		]
+	}
+}`,
+		},
+		{
+			name: "Block with a splat expression",
+			input: `locals {
+	thing = [{"id": 1}, {"id": 2}, {"id": 3}][*].id
+}`,
+			expected: `{
+	"locals": {
+		"thing": [
+			1,
+			2,
+			3
+		]
+	}
+}`,
+		},
+		{
+			name: "Block with a scope traversal expression",
+			input: `locals {
+	thing = [1, 2, 3][1]
+}`,
+			expected: `{
+	"locals": {
+		"thing": 2
+	}
+}`,
+		},
+		{
+			name: "Block with an object cons expression",
+			input: `locals {
+	thing = {
+		a = "1"
+		b = "2"
+	}
+}`,
+			expected: `{
+	"locals": {
+		"thing": {
+			"a": "1",
+			"b": "2"
+		}
+	}
+}`,
+		},
+		{
+			name: "Block with heredoc",
+			input: `
+locals {
+	heredoc = <<EOF
+		Another heredoc, that
+		doesn't remove indentation
+	EOF
+}`,
+			expected: `{
+	"locals": {
+		"heredoc": "\t\tAnother heredoc, that\n\t\tdoesn't remove indentation\n"
+	}
+}`,
+		},
+		{
+			name: "Block with a missing reference",
+			input: `
+locals {
+	cond = test3 > 2 ? 1: 0
+}`,
+			expected: `{
+	"locals": {
+		"cond": "${test3 \u003e 2 ? 1: 0}"
+	}
+}`,
+		},
+		{
+			name: "Block with functions to simplify",
+			input: `locals {
+		a = split("-", "xyx-abc-def")
+		x = 1 + 2
+		y = pow(2,3)
+		t = "x=${4+abs(2-3)*parseint("02",16)}"
+		j = jsonencode({
+			a = "a"
+			b = 5
+		})
+		with_vars = x + 1
+	}`,
+			expected: `{
+	"locals": {
+		"a": [
+			"xyx",
+			"abc",
+			"def"
+		],
+		"j": "{\"a\":\"a\",\"b\":5}",
+		"t": "x=6",
+		"with_vars": "${x + 1}",
+		"x": 3,
+		"y": 8
+	}
+}`,
+		},
+		{
+			name: "Block with nested attributes",
+			input: `
+locals {
+	other = {
+		3 = 1
+		"a.b.c[\"hi\"][3].*" = 3
+		a.b.c = "True"
+	}
+}`,
+			expected: `{
+	"locals": {
+		"other": {
+			"3": 1,
+			"a.b.c": "True",
+			"a.b.c[\"hi\"][3].*": 3
+		}
+	}
+}`,
+		},
+		{
+			name: "Local block referencing an attribute defined on itself",
+			input: `
+locals {
+	x = -10
+	y = -x
+	z = -(1 + 4)
+}`,
+			expected: `{
+	"locals": {
+		"x": -10,
+		"y": "${-x}",
+		"z": -5
+	}
+}`,
+		},
+		{
+			name: "Mixed types of blocks (data, variable) with referenced variables",
+			input: `
+data "terraform_remote_state" "remote" {
+	backend = "s3"
+	config = {
+		profile = var.profile
+		region  = var.region
+		bucket  = "mybucket"
+		key     = "mykey"
+	}
+}
+variable "profile" {}
+variable "region" {
+	default = "us-east-1"
+}`,
+			expected: `{
+	"data": {
+		"terraform_remote_state": {
+			"remote": {
+				"backend": "s3",
+				"config": {
+					"bucket": "mybucket",
+					"key": "mykey",
+					"profile": "${var.profile}",
+					"region": "${var.region}"
+				}
+			}
+		}
+	},
+	"variable": {
+		"profile": {},
+		"region": {
+			"default": "us-east-1"
+		}
+	}
+}`,
+		},
+		{
+			name: "Block referencing a defined input variable",
+			input: `
+ resource "aws_instance" "app_server" {
+   ami           = "ami-08d70e59c07c61a3a"
+   instance_type = "t2.micro"
+
+   tags = {
+    Name = var.instance_name
+   }
+ }`,
+			expected: `{
+	"resource": {
+		"aws_instance": {
+			"app_server": {
+				"ami": "ami-08d70e59c07c61a3a",
+				"instance_type": "t2.micro",
+				"tags": {
+					"Name": "test"
+				}
+			}
+		}
+	}
+}`,
+			variables: ModuleVariables{
+				inputs: ValueMap{
+					"instance_name": cty.StringVal("test"),
+				},
+			},
+		},
+		{
+			name: "Block referencing a defined local variable",
+			input: `
+ resource "aws_instance" "app_server" {
+   ami           = "ami-08d70e59c07c61a3a"
+   instance_type = "t2.micro"
+
+   tags = {
+    Name = local.instance_name
+   }
+ }`,
+			expected: `{
+	"resource": {
+		"aws_instance": {
+			"app_server": {
+				"ami": "ami-08d70e59c07c61a3a",
+				"instance_type": "t2.micro",
+				"tags": {
+					"Name": "test"
+				}
+			}
+		}
+	}
+}`,
+			variables: ModuleVariables{
+				locals: ValueMap{
+					"instance_name": cty.StringVal("test"),
+				},
+			},
+		},
+		{
+			name: "Variable block referencing a defined local variable",
+			input: `
+ 	variable "test1" {
+		type = "string"
+   		test2 = local.instance_name
+ 	}`,
+			expected: `{
+	"variable": {
+		"test1": {
+			"test2": "test",
+			"type": "string"
+		}
+	}
+}`,
+			variables: ModuleVariables{
+				locals: ValueMap{
+					"instance_name": cty.StringVal("test"),
+				},
+			},
+		},
+		{
+			name: "Local block referencing a defined local variable",
+			input: `
+ 	locals {
+   		test = local.instance_name
+ 	}`,
+			expected: `{
+	"locals": {
+		"test": "test"
+	}
+}`,
+			variables: ModuleVariables{
+				locals: ValueMap{
+					"instance_name": cty.StringVal("test"),
+				},
+			},
+		},
+		{
+			name: "Local block referencing a variable in the attribute key",
+			input: `
+locals {
+	other = {	
+		"${local.test2}" = 4
+		3 = 1
+		"local.test1" = 89
+	}
+}`,
+			expected: `{
+	"locals": {
+		"other": {
+			"3": 1,
+			"b": 4,
+			"local.test1": 89
+		}
+	}
+}`,
+			variables: ModuleVariables{
+				locals: ValueMap{
+					"test1": cty.StringVal("a"),
+					"test2": cty.StringVal("b"),
+				},
+			},
+		},
+		{
+			name: "Block referencing an undefined variable",
+			input: `
+ resource "aws_instance" "app_server" {
+   ami           = "ami-08d70e59c07c61a3a"
+   instance_type = "t2.micro"
+
+   tags = {
+    Name = var.instance_name
+   }
+ }`,
+			expected: `{
+	"resource": {
+		"aws_instance": {
+			"app_server": {
+				"ami": "ami-08d70e59c07c61a3a",
+				"instance_type": "t2.micro",
+				"tags": {
+					"Name": "${var.instance_name}"
+				}
+			}
+		}
+	}
+}`,
+			variables: ModuleVariables{
+				inputs: ValueMap{
+					"wrong_name": cty.StringVal("test"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := ParseHclToJson("test", tc.input, tc.variables)
+			require.Nil(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestParseHCL2JSONFailure(t *testing.T) {
+	type test struct {
+		name     string
+		input    string
+		expected string
+	}
+	tests := []test{
+		{
+			name: "Invalid HCL",
+			input: `
+block "label_one" {
+	attribute = "value"
+`,
+			expected: "Invalid HCL provided",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseHclToJson("test", tc.input, ModuleVariables{})
+			require.NotNil(t, err)
+			assert.Equal(t, tc.expected, err.Error())
+			assert.True(t, isUserError(err))
+		})
+	}
+}

--- a/terraform/variables.go
+++ b/terraform/variables.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -9,14 +10,35 @@ import (
 
 type ValueMap map[string]cty.Value
 
+type ExpressionMap map[string]hcl.Expression
+
 type ModuleVariables struct {
 	inputs ValueMap
 	locals ValueMap
 }
 
-type ParserVariables map[string]ValueMap
-
 type InputVariablesByFile map[string]ValueMap
+
+// ExtractVariables extracts the input variables and local values from the provided file
+func ExtractVariables(file File) (ValueMap, ExpressionMap, error) {
+	inputsMap := ValueMap{}
+	localsMap := ExpressionMap{}
+	var hclDiags hcl.Diagnostics
+
+	if isValidInputVariablesFile(file.fileName) {
+		var inputHclDiags hcl.Diagnostics
+		inputsMap, hclDiags = extractInputVariablesFromFile(file)
+		hclDiags = append(hclDiags, inputHclDiags...)
+	}
+
+	if isValidTerraformFile(file.fileName) {
+		var localsHclDiags hcl.Diagnostics
+		localsMap, localsHclDiags = extractLocalsFromFile(file)
+		hclDiags = append(hclDiags, localsHclDiags...)
+	}
+
+	return inputsMap, localsMap, hclDiags
+}
 
 func extractInputVariablesFromFile(file File) (ValueMap, hcl.Diagnostics) {
 	var inputVariables ValueMap
@@ -34,32 +56,22 @@ func extractInputVariablesFromFile(file File) (ValueMap, hcl.Diagnostics) {
 	return inputVariables, hclDiags
 }
 
-func extractLocalsFromFile(file File, inputsMap ValueMap) (ValueMap, hcl.Diagnostics) {
-	var localsMap = ValueMap{}
-	var hclDiags hcl.Diagnostics
+func extractLocalsFromFile(file File) (ExpressionMap, hcl.Diagnostics) {
+	localExprsMap := ExpressionMap{}
 
 	bodyContent, _, hclDiags := file.hclFile.Body.PartialContent(tfFileLocalSchema)
 	if hclDiags.HasErrors() {
-		return localsMap, hclDiags
+		return localExprsMap, hclDiags
 	}
 
 	for _, block := range bodyContent.Blocks {
 		attrs, _ := block.Body.JustAttributes()
 		for localName, attr := range attrs {
-			localVal, diags := attr.Expr.Value(&hcl.EvalContext{
-				Functions: terraformFunctions,
-				Variables: NewParserVariables(ModuleVariables{
-					inputs: inputsMap,
-				}),
-			})
-			if diags.HasErrors() {
-				continue
-			}
-			localsMap[localName] = localVal
+			localExprsMap[localName] = attr.Expr
 		}
 	}
 
-	return localsMap, hclDiags
+	return localExprsMap, hclDiags
 }
 
 // Logic inspired from https://github.com/hashicorp/terraform/blob/f266d1ee82d1fa4d882c146cc131fec4bef753cf/internal/configs/named_values.go#L113
@@ -122,4 +134,49 @@ func mergeInputVariables(inputVariablesByFile InputVariablesByFile) ValueMap {
 	}
 
 	return combinedInputVariables
+}
+
+var maxLocalsDerefIterations = 32
+
+func dereferenceLocals(localExprsMap ExpressionMap, inputs ValueMap) ValueMap {
+	currLocalVals := ValueMap{}
+	nextLocalVals := ValueMap{}
+
+	for i := 0; i < maxLocalsDerefIterations; i++ {
+		for localName, localExpr := range localExprsMap {
+			newLocalVal, hclDiags := localExpr.Value(&hcl.EvalContext{
+				Variables: createValueMap(ModuleVariables{
+					inputs: inputs,
+					locals: currLocalVals,
+				}),
+				Functions: terraformFunctions,
+			})
+
+			// the local cannot be dereferenced so move onto the next one
+			if !newLocalVal.IsKnown() || hclDiags.HasErrors() {
+				continue
+			}
+
+			// a local has been dereferenced so store it in the
+			nextLocalVals[localName] = newLocalVal
+		}
+
+		// stop if the local values haven't changed between dereferencing loops
+		if reflect.DeepEqual(currLocalVals, nextLocalVals) {
+			break
+		}
+
+		for localName, localVal := range nextLocalVals {
+			currLocalVals[localName] = localVal
+		}
+	}
+
+	return nextLocalVals
+}
+
+func createValueMap(variables ModuleVariables) ValueMap {
+	return ValueMap{
+		"var":   cty.ObjectVal(variables.inputs),
+		"local": cty.ObjectVal(variables.locals),
+	}
 }


### PR DESCRIPTION
## What this does
Following the [PR where we added support for local values](https://github.com/snyk/snyk-iac-parsers/pull/18), we would like to add support for local values that reference other local values.

## Background context
There are multiple methods to achieve this functionality, this PR implements the brute-force method which is very similar to tf-sec's implementation.
We are iterating through the local values and using the available context we are trying to dereference each local value, if we managed to successfully dereference the value we add it context to our available context.
The loop will stop in two cases, if we reach the maximum allowed iterations or if the context from the last iteration is equal to the current context (or in other words, in the latest iteration we didn't manage to dereference any of the values or that we finished to dereference all of the values).

## More information
[CFG-1500](https://snyksec.atlassian.net/browse/CFG-1500)
[Terraform - Local values](https://www.terraform.io/language/values/locals)