### PR TITLE
chore: add automated release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release package
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    name: Push Latest Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install release-it
+        run: npm i -g release-it@v14.12.5 @release-it/conventional-changelog
+
+      - name: Push new tag and release
+        run: |
+          echo "Computing tag using semver..."
+          echo 'deb [trusted=yes] https://apt.fury.io/caarlos0/ /' | sudo tee /etc/apt/sources.list.d/caarlos0.list
+          sudo apt update
+          sudo apt install svu=1.7.0
+          TAG=$(svu)
+          echo "Checking if a release should be done..."    
+          if [ $(git tag -l "$TAG") ]; then
+            echo "Tag ${TAG} already exists!"
+            echo "Commit must not generate a new release"
+          else
+            echo "Tag ${TAG} does not exist!"
+            echo "Releasing a new tag ${TAG} with our commits..."
+          
+            # Hard-code user config
+            git config user.email "snyksec@users.noreply.github.com"
+            git config user.name "Snyk"
+  
+            release-it
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 cover.out
 tmp/
 scripts/opa/opa
+package-lock.json

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,20 @@
+{
+  "git": {
+    "commit": false,
+    "tag": true,
+    "push": false
+  },
+  "github": {
+    "release": true
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "preset": {
+        "name": "angular"
+      }
+    }
+  },
+  "hooks": {
+    "after:bump": ""
+  }
+}

--- a/README.md
+++ b/README.md
@@ -31,13 +31,6 @@ Tests can be run using the `go test` command:
 
 Before committing code should be formatted with `go fmt` and linted with `golangci-lint run`. The CircleCI runner will enforce this for each opened pull request.
 
-## Release
-
-For now the release process is manual. Follow the steps below to create a new version of the `github.com/snyk/snyk-iac-parsers` package:
-1. Retrieve the latest tag from https://github.com/snyk/snyk-iac-parsers/tags (e.g. `v0.0.5`).
-2. Create a new tag by running `git tag -a v0.0.6 -m "Relase v0.0.6"`
-3. Push the tag by running `git push origin v0.0.6`
-
 ## Contributing
 
 This project is developed in open as a dependency of the [snyk/snyk-iac-rules](https://github.com/snyk/snyk-iac-rules) project. Should you wish to make a contribution please open a pull request against this repository with a clear description of the change with tests demonstrating the functionality. You will also need to agree to the [Contributor Agreement](./Contributor-Agreement.md) before the code can be accepted and merged.


### PR DESCRIPTION
### What this does
This adds an automated release process using [release-it](https://github.com/release-it/release-it) for creating the GitHub release.

Because `release-it` generates new tags/releases for `chore:` commits too (see https://github.com/release-it/release-it/issues/783), we are using https://github.com/caarlos0/svu to generate tags and conditionally create releases. The same way we do in [snyk-iac-rules](https://github.com/snyk/snyk-iac-rules/blob/develop/.github/workflows/release.yml).

### How it was tested
I've run some tests by changing the branch to the current one. See screenshots.

Example run for `chore:` to prove that semver works: https://github.com/snyk/snyk-iac-parsers/actions/runs/1951239680
Example run for `feat:` to prove that semver works: https://github.com/snyk/snyk-iac-parsers/runs/5463892569?check_suite_focus=true
- the tag is pushed by Snyksec
- the release is created by `cloud-config-ro`

### Related tickets
https://snyksec.atlassian.net/browse/CFG-1653

### Screenshots
![Screenshot 2022-03-08 at 11 52 52](https://user-images.githubusercontent.com/81559517/157233237-67c9a002-41ff-40d2-a1e3-1009b45402db.png)

### Additional context
We also considered using [semantic-release](https://github.com/semantic-release/semantic-release) but it is built for NPM.
