### PR TITLE
Chore: Upgrade deprecated CircleCI Docker images [CFG-1655]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
   regression-test-linux:
     <<: *defaults
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.17.2
     steps:
       - checkout
       - build
@@ -63,7 +63,7 @@ jobs:
       - test
   security-oss:
     docker:
-      - image: cimg/go:1.17.2 
+      - image: cimg/go:1.17.2
     steps:
       - checkout
       - snyk/scan:
@@ -73,7 +73,7 @@ jobs:
           organization: snyk-iac-group-seceng
   security-code:
     docker:
-      - image: cimg/go:1.17.2 
+      - image: cimg/go:1.17.2
     steps:
       - checkout
       - snyk/scan:


### PR DESCRIPTION
### What this does

- Upgrades all deprecated CircleCi convenience images.

### Background context

We received an email from CircleCI that informed us that we need to upgrade our Convenience images cause the old ones are not going to work after March 15. The email stated as follows:

> On Tuesday, March 15, 2022, GitHub will be changing which keys are supported in SSH and removing unencrypted Git protocol. Please reference the [blog post](https://go.circleci.com/NDg1LVpNSC02MjYAAAGDBUMks2mgFO0aDmKMR7Ph2cssUQ-bn6DX2Lf28U20tyKI3KXvALu4zW6HlGF_XvM0D074vu8=) GitHub released regarding this change.   
> 
> As a result of GitHub's planned changes, any image that is used in a job from a project created between November 2, 2021 and January 13, 2022 needs to use a version of OpenSSH that is greater than or equal to version 7.2. CircleCI has updated all [Convenience images](https://go.circleci.com/NDg1LVpNSC02MjYAAAGDBUMks6_UgCzToPpp0HlVNCZ7YZOoa4ilba8_fHWEokk7Zeil6G4S3iG-aCSg2mc-cbDF7aw=) to use at least version 7.2 of OpenSSH with the exception of the legacy Convenience images that were deprecated on December 31, 2021.

### Additional information
- [Relevant thread on #iac-config-team](https://snyk.slack.com/archives/C02JMMTLUF9/p1646724880728649)
- [Relevant thread on #chatter-rnd](https://snyk.slack.com/archives/C07N668DA/p1646906400327689)

### Screenshots

<details>
  <summary>Screenshot of the email from CircleCI:</summary>
        <img src="https://user-images.githubusercontent.com/46415136/157655383-255eae52-8495-4adc-ba91-273be5c0b6db.png"/>
</details>
