### PR TITLE
chore: remove snyk policy expiry for MPL license

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,5 @@ ignore:
   'snyk:lic:golang:github.com:hashicorp:hcl:v2:MPL-2.0':
     - '*':
         reason: "Project is distributed with unmodified hashicorp/hcl dependency"
-        expires: 2022-03-29T12:19:52.897Z
         created: 2021-11-29T12:19:52.899Z
 patch: {}


### PR DESCRIPTION
This license is covered so we can safely ignore it permanently and no need to have an expiry. 