### PR TITLE
fix: nil resolved resources map

### DIFF
--- a/terraform_plan.go
+++ b/terraform_plan.go
@@ -91,7 +91,7 @@ func parseTerraformPlan(planJson TerraformPlanJson, isFullScan bool) TerraformSc
 		}
 		mode := "resource"
 		// only update the references in resources that have some resolved attributes already
-		if resolvedResource, ok := scanInput[mode][resource.Type][getResourceName(resource)].(map[string]interface{}); ok {
+		if resolvedResource, ok := scanInput[mode][resource.Type][getResourceName(resource)].(map[string]interface{}); ok && resolvedResource != nil {
 			expressions := getExpressions(resource.Expressions)
 			for k, v := range expressions {
 				// only add non existing attributes. If we already have resolved value do not overwrite it with reference


### PR DESCRIPTION
### What this does

- Introduces a fix following a nil map assignment alert received ([thread](https://snyk.slack.com/archives/C023NA9FQCU/p1671343160064919))

### Additional Information

It looks like we’re only checking if the conversion is possible here, not checking if the value is nil.
I tried simulating this here:
```
	a := map[string]map[string]string{}
	var b interface{} = a["test"]
	if _, ok := b.(map[string]string); ok {
		log.Println("A")
	} else {
		log.Println("B")
	}
```
Based on the comments it looks like this was the intention. I’ll open a fix PR