### PR TITLE
MPL license should be ignored permanently

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,5 @@ ignore:
   'snyk:lic:golang:github.com:hashicorp:hcl:v2:MPL-2.0':
     - '*':
         reason: "Project is distributed with unmodified hashicorp/hcl dependency"
-        expires: 2022-03-29T12:19:52.897Z
         created: 2021-11-29T12:19:52.899Z
 patch: {}


### PR DESCRIPTION
This license is covered so we can safely ignore it permanently.
In this case there’s no problem in distributing the project using the MPL 2.0-governed code, on the basis that: (i) no modification has been made to the code; (ii) the unmodified code is in its own separate file, not inserted into another file; (iii) we comply with the notice and attribution requirements set out in section 3.1 of MPL 2.0 - by including the copyright notice attached to the code, telling users that the code is covered by MPL 2.0, and providing a link to the licence at https://www.mozilla.org/en-US/MPL/2.0/; and (iv) we make the MPL’d source code available alongside the binaries.