### PR TITLE
feat: Use the latest, custom Terraform parser

### DIFF
--- a/hcl2_jsonencode_test.go
+++ b/hcl2_jsonencode_test.go
@@ -1,0 +1,33 @@
+package parsers_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	parsers "github.com/snyk/snyk-iac-parsers"
+)
+
+func TestParseHCL2WithJSONEncode(t *testing.T) {
+	input, err := os.ReadFile(filepath.Join("testdata", "terraform", "jsonencode.tf"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	var result interface{}
+
+	if err := parsers.ParseHCL2([]byte(input), &result); err != nil {
+		t.Fatalf("parse HCL2: %v", err)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal parsed input: %v", err)
+	}
+
+	if strings.Contains(string(data), "jsonencode") {
+		t.Fatalf("jsonencode has not been evaluated")
+	}
+}

--- a/testdata/terraform/jsonencode.tf
+++ b/testdata/terraform/jsonencode.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_role_policy" "test_policy" {
+  name = "test_policy"
+  role = aws_iam_role.test_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+  tags = {
+    type = "service"
+  }
+}


### PR DESCRIPTION
The `snyk` CLI uses the version of the Terraform parser implemented by the `terraform` package in this library. The `ParseHCL2` function, exported by this library and used by `snyk-iac-rules`, still uses plain `hcl2json`. 

Because of this difference, users of `snyk-iac-rules` and users of `snyk` don't have a consistent developer experience. A user writing a custom rule, and testing it via `snyk-iac-rules`, might be unable to run that rule in `snyk`. An example of this incompatibility is the handling of the `jsonencode` function in Terraform code. 

Given this input file:

```hcl
resource "aws_iam_role_policy" "test_policy" {
  name = "test_policy"
  role = aws_iam_role.test_role.id
  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {
        Action = [
          "ec2:*",
        ]
        Effect   = "Allow"
        Resource = "*"
      },
    ]
  })
}
```

`snyk-iac-rules`, which is still based on `hcl2json`, produces this:

```json
{
  "resource": {
    "aws_iam_role_policy": {
      "test_policy": {
        "name": "test_policy",
        "policy": "${jsonencode({\r\n    Version = \"2012-10-17\"\r\n    Statement = [\r\n      {\r\n        Action = [\r\n          \"ec2:*\",\r\n        ]\r\n        Effect   = \"Allow\"\r\n        Resource = \"*\"\r\n      },\r\n    ]\r\n  })}",
        "role": "${aws_iam_role.test_role.id}"
      }
    }
  }
}

```

The parser in the `snyk` CLI, based on the `terraform` package, produces this:

```json
{
  "resource": {
    "aws_iam_role_policy": {
      "test_policy": {
        "name": "test_policy",
        "policy": "{\"Statement\":[{\"Action\":[\"ec2:*\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}",
        "role": "${aws_iam_role.test_role.id}"
      }
    }
  }
}
```

This PR fixes this incompatibility by using the same parser everywhere, consistently. Moreover, this PR stacks on top of #31, which should be merged first.