### PR TITLE
fix: Merge input variables in a deterministic way

### DIFF
--- a/terraform/variables.go
+++ b/terraform/variables.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -120,9 +121,16 @@ func mergeInputVariables(inputVariablesByFile InputVariablesByFile) ValueMap {
 	combinedInputVariables := make(ValueMap)
 
 	fileNames := make([]string, 0, len(inputVariablesByFile))
+
 	for fileName := range inputVariablesByFile {
 		fileNames = append(fileNames, fileName)
 	}
+
+	// The order of iteration over maps is not deterministic. In order for this
+	// function to return deterministic results, sort the slice of file names
+	// first.
+
+	sort.Strings(fileNames)
 
 	prioritisedFileNames := orderFilesByPriority(fileNames)
 


### PR DESCRIPTION
`mergeInputVariables()` determines the order for merging input variables by sorting a slice of file names by priority. The name of the files are extracted from the keys of a map, but iIterating over a map is not deterministic in Go. To make the implementation of `mergeInputVariables()` deterministic, and to prevent flakiness in `TestMergeVariablesFromTerraformFiles`, the slice of file names should be sorted before being sorted again by priority.