### PR TITLE
fix: Upgrade GitHub actions and fix release-it installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release package
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   build:
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: "14"
 
       - name: Install release-it
-        run: npm i -g release-it@v14.12.5 @release-it/conventional-changelog
+        run: npm i release-it@v14.12.5 @release-it/conventional-changelog
 
       - name: Push new tag and release
         run: |
@@ -37,12 +37,12 @@ jobs:
           else
             echo "Tag ${TAG} does not exist!"
             echo "Releasing a new tag ${TAG} with our commits..."
-          
+
             # Hard-code user config
             git config user.email "snyksec@users.noreply.github.com"
             git config user.name "Snyk"
-  
-            release-it
+
+            npx release-it
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_ACCESS_TOKEN }}


### PR DESCRIPTION
Fixes the release workflow:
- Some GitHub actions are deprecated because they run on Node 12.
- `release-it` is unable to find `@release-it/conventional-changelog` when installed globally.