### PR TITLE
fix: Update release-it configuration

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -16,5 +16,9 @@
   },
   "hooks": {
     "after:bump": ""
+  },
+  "npm": {
+    "publish": false,
+    "ignoreVersion": true
   }
 }


### PR DESCRIPTION
Configure release-it to skip publishing to NPM and reading the version from `package.json`.