### PR TITLE
fix: report parser panic as error [IAC-3138]

### DIFF
--- a/terraform/hcl2json.go
+++ b/terraform/hcl2json.go
@@ -74,9 +74,10 @@ func parseModuleFiles(files map[string]File, vars ModuleVariables, parseRes *Par
 			if err != nil {
 				// skip non-user errors
 				if isUserError(err) {
-					parseRes.debugLogs[fileName] = GenerateDebugLogs(err)
 					parseRes.failedFiles[fileName] = err.Error()
 				}
+				// but still log them
+				parseRes.debugLogs[fileName] = GenerateDebugLogs(err)
 				continue
 			}
 			parseRes.parsedFiles[fileName] = parsedJson


### PR DESCRIPTION
https://snyksec.atlassian.net/browse/IAC-3138

Fixes this problem: if the parser panics unable to parse one file, no results are reported for all other files. 